### PR TITLE
Fix deprecated lifecycle methods componentWillReceiveProps and componentWillMount

### DIFF
--- a/src/ReactNativeZoomableGestures.js
+++ b/src/ReactNativeZoomableGestures.js
@@ -40,8 +40,10 @@ class ReactNativeZoomableGestures extends React.Component {
     const parent = ReactNativeZoomableView.prototype.parentHandleMoveShouldSetPanResponder.call(this);
   }
 
-  componentWillReceiveProps(props) {
-    this.swipeConfig = Object.assign(swipeConfig, props.config);
+ static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps !== prevState) {
+      this.swipeConfig = Object.assign(swipeConfig, nextProps.config);
+    }
   }
 /*
 

--- a/src/ReactNativeZoomableView.js
+++ b/src/ReactNativeZoomableView.js
@@ -19,6 +19,16 @@ class ReactNativeZoomableView extends Component {
   constructor(props) {
     super(props);
 
+    this.gestureHandlers = PanResponder.create({
+      onStartShouldSetPanResponder: this._handleStartShouldSetPanResponder,
+      onMoveShouldSetPanResponder: this._handleMoveShouldSetPanResponder,
+      onPanResponderGrant: this._handlePanResponderGrant,
+      onPanResponderMove: this._handlePanResponderMove,
+      onPanResponderRelease: this._handlePanResponderEnd,
+      onPanResponderTerminationRequest: evt => false,
+      onShouldBlockNativeResponder: evt => false,
+    });
+    
     this.state = {
       zoomLevel: props.initialZoom,
       ...initialState,
@@ -36,18 +46,6 @@ class ReactNativeZoomableView extends Component {
       distanceTop: 0,
       distanceBottom: 0,
     };
-  }
-
-  componentWillMount() {
-    this.gestureHandlers = PanResponder.create({
-      onStartShouldSetPanResponder: this._handleStartShouldSetPanResponder,
-      onMoveShouldSetPanResponder: this._handleMoveShouldSetPanResponder,
-      onPanResponderGrant: this._handlePanResponderGrant,
-      onPanResponderMove: this._handlePanResponderMove,
-      onPanResponderRelease: this._handlePanResponderEnd,
-      onPanResponderTerminationRequest: evt => false,
-      onShouldBlockNativeResponder: evt => false,
-    });
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
In regards to #17 .  I replaced componentWillReceiveProps with getDerivedStateFromProps and moved the this.gestureHandlers PanResponder into the constructor. 