### PR TITLE
Add captureEvent to ReactNativeZoomableViewProps

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -40,6 +40,7 @@ declare module '@dudigital/react-native-zoomable-view' {
     initialOffsetX?: number;
     initialOffsetY?: number;
     longPressDuration?: number;
+    captureEvent?: boolean;
     onDoubleTapBefore?: (event: Event, gestureState: PanResponderGestureState, zoomableViewEventObject: ZoomableViewEvent) => void;
     onDoubleTapAfter?: (event: Event, gestureState: PanResponderGestureState, zoomableViewEventObject: ZoomableViewEvent) => void;
     onShiftingBefore?: (event: Event, gestureState: PanResponderGestureState, zoomableViewEventObject: ZoomableViewEvent) => boolean;


### PR DESCRIPTION
I noticed `captureEvent` was missing in my TypeScript project so just adding it to the typings file