### PR TITLE
Fix not triggering onDoubleTapBefore

### DIFF
--- a/src/ReactNativeZoomableView.js
+++ b/src/ReactNativeZoomableView.js
@@ -507,7 +507,7 @@ class ReactNativeZoomableView extends Component {
       return;
     }
 
-    if (this.props.onDoubleTap) {
+    if (this.props.onDoubleTapBefore) {
       this.props.onDoubleTapBefore(e, gestureState, this._getZoomableViewEventObject());
     }
 


### PR DESCRIPTION
Fixed bug where it checks if there is onDoubleTap instead onDoubleTapBefore to call it.