### PR TITLE
Fixed offset values in onDoubleTapAfter to be current and not the las…

### DIFF
--- a/src/ReactNativeZoomableView.js
+++ b/src/ReactNativeZoomableView.js
@@ -532,14 +532,15 @@ class ReactNativeZoomableView extends Component {
       zoomPositionCoordinates.x,
       zoomPositionCoordinates.y,
       nextZoomStep,
-      true
+      true,
+      () => {
+        if (onDoubleTapAfter) {
+          onDoubleTapAfter(e, gestureState, this._getZoomableViewEventObject({
+            zoomLevel: nextZoomStep,
+          }));
+        }
+      }
     );
-
-    if (onDoubleTapAfter) {
-      onDoubleTapAfter(e, gestureState, this._getZoomableViewEventObject({
-        zoomLevel: nextZoomStep,
-      }));
-    }
 
   }
 


### PR DESCRIPTION
Fixes the problem, that ajay raised here https://github.com/DuDigital/react-native-zoomable-view/issues/60