### PR TITLE
feat: Allow handling pan-responder interruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Sometimes you need to change deeper level behavior, so we prepared these panresp
 | onMoveShouldSetPanResponder | description | event, gestureState, zoomableViewEventObject, baseComponentResult | {boolean} whether panresponder should be set or not |
 | onPanResponderGrant | description | event, gestureState, zoomableViewEventObject | void |
 | onPanResponderEnd | Will be called when gesture ends (more accurately, on pan responder "release") | event, gestureState, zoomableViewEventObject | void |
+| onPanResponderTerminate | Will be called when the gesture is force-interrupted by another handler | event, gestureState, zoomableViewEventObject | void |
+| onPanResponderTerminationRequest | Callback asking whether the gesture should be interrupted by another handler (**iOS only** due to https://github.com/facebook/react-native/issues/27778, https://github.com/facebook/react-native/issues/5696, ...) | event, gestureState, zoomableViewEventObject | void |
 | onPanResponderMove | Will be called when user moves while touching | event, gestureState, zoomableViewEventObject | void |
 
 ### zoomableViewEventObject

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Sometimes you need to change deeper level behavior, so we prepared these panresp
 | onStartShouldSetPanResponder | description | event, gestureState, zoomableViewEventObject, baseComponentResult | {boolean} whether panresponder should be set or not |
 | onMoveShouldSetPanResponder | description | event, gestureState, zoomableViewEventObject, baseComponentResult | {boolean} whether panresponder should be set or not |
 | onPanResponderGrant | description | event, gestureState, zoomableViewEventObject | void |
-| onPanResponderEnd | Will be called when gesture ends | event, gestureState, zoomableViewEventObject | void |
+| onPanResponderEnd | Will be called when gesture ends (more accurately, on pan responder "release") | event, gestureState, zoomableViewEventObject | void |
 | onPanResponderMove | Will be called when user moves while touching | event, gestureState, zoomableViewEventObject | void |
 
 ### zoomableViewEventObject

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -58,7 +58,8 @@ class ReactNativeZoomableView extends Component<ReactNativeZoomableViewProps, Re
       onPanResponderGrant: this._handlePanResponderGrant,
       onPanResponderMove: this._handlePanResponderMove,
       onPanResponderRelease: this._handlePanResponderEnd,
-      onPanResponderTerminationRequest: (evt) => false,
+      onPanResponderTerminate: props.onPanResponderTerminate,
+      onPanResponderTerminationRequest: props.onPanResponderTerminationRequest ?? ((evt) => false),
       onShouldBlockNativeResponder: (evt) => false,
     });
 

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -118,6 +118,16 @@ declare module '@dudigital/react-native-zoomable-view' {
       gestureState: PanResponderGestureState,
       zoomableViewEventObject: ZoomableViewEvent,
     ) => boolean;
+    onPanResponderTerminate?: (
+      event: Event,
+      gestureState: PanResponderGestureState,
+      zoomableViewEventObject: ZoomableViewEvent,
+    ) => void;
+    onPanResponderTerminationRequest?: (
+      event: Event,
+      gestureState: PanResponderGestureState,
+      zoomableViewEventObject: ZoomableViewEvent,
+    ) => boolean;
   }
 
   export interface ReactNativeZoomableViewState {


### PR DESCRIPTION
Hello!

Using RNZoomableView in a ScrollView/FlatList/... feels buggy due to the ScrollView interrupting the lib gesture

With the 2 new callbacks, we can:
- prevent the gesture from being interrupted on iOS
- be notified of interruption on Android


(Which is pretty useful for a strategy where you want to dynamically set scrollEnabled={false} on the parent ScrollView while RNZoomableView is being used)