### PR TITLE
Add a feature to stay at maxZoom instead of resetting to initialZoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We are happy to hear from you about bugs, issues and would also appreciate your 
 
 `$ npm install @dudigital/react-native-zoomable-view --save`
 
-or 
+or
 
 `$ yarn add @dudigital/react-native-zoomable-view`
 
@@ -37,11 +37,13 @@ Therefore no platform specific configuration needs to be done.
 Just use it as a drop in component instead of a normal view.
 
 Import ReactNativeZoomableView:
+
 ```JSX
 import ReactNativeZoomableView from '@dudigital/react-native-zoomable-view/src/ReactNativeZoomableView';
 ```
 
 Use the component:
+
 ```JSX
 <ReactNativeZoomableView
    maxZoom={1.5}
@@ -120,48 +122,47 @@ https://snack.expo.io/SkltQtr8Q
 
 https://github.com/DuDigital/react-native-zoomable-view-example
 
-
 ### Props
 
 #### Options
 
 These options can be used to limit and change the zoom behavior.
 
-| name | type | description | default |
-| ---- | ----------- | ------ | --------------- |
-| zoomEnabled | boolean | Can be used to enable or disable the zooming dynamically | true |
-| initialZoom | number | Initial zoom level on startup | 1.0 |
-| maxZoom | number | Maximum possible zoom level (zoom in). Can be set to `null` to allow unlimited zooming | 1.5 |
-| minZoom | number | Minimum possible zoom level (zoom out) | 0.5 |
-| doubleTapDelay | number  | How much delay will still be recognized as double press (ms) | 300 |
-| doubleTapZoomToCenter | boolean | If true, double tapping will always zoom to center of View instead of the direction it was double tapped in
-| bindToBorders | boolean | If true, it makes sure the object stays within box borders | true |
-| zoomStep | number | How much zoom should be applied on double tap | 0.5 |
-| pinchToZoomInSensitivity | number | the level of resistance (sensitivity) to zoom in (0 - 10) - higher is less sensitive | 3 |
-| pinchToZoomOutSensitivity | number | the level of resistance (sensitivity) to zoom out (0 - 10) - higher is less sensitive | 1 |
-| zoomCenteringLevelDistance | number | the (zoom level - 0 - maxZoom) distance for pinch to zoom actions until they are shifted on new pinch to zoom center - higher means it centeres slower | 0.5 |
-| movementSensibility | number | how resistant should shifting the view around be? (0.5 - 5) - higher is less sensitive | 1.9 |
-| initialOffsetX | number | The horizontal offset the image should start at | 0 |
-| initialOffsetY | number | The vertical offset the image should start at | 0 |
-| longPressDuration | number | Duration in ms until a press is considered a long press | 700 |
-| captureEvent | boolean | Defines whether the pan responder of the parent element should be captured. (useful for react-native modals, set it to true) | false |
+| name                       | type    | description                                                                                                                                            | default |
+| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| zoomEnabled                | boolean | Can be used to enable or disable the zooming dynamically                                                                                               | true    |
+| initialZoom                | number  | Initial zoom level on startup                                                                                                                          | 1.0     |
+| maxZoom                    | number  | Maximum possible zoom level (zoom in). Can be set to `null` to allow unlimited zooming                                                                 | 1.5     |
+| minZoom                    | number  | Minimum possible zoom level (zoom out)                                                                                                                 | 0.5     |
+| doubleTapDelay             | number  | How much delay will still be recognized as double press (ms)                                                                                           | 300     |
+| doubleTapZoomToCenter      | boolean | If true, double tapping will always zoom to center of View instead of the direction it was double tapped in                                            |
+| stayAtMaxZoom              | boolean | If true, the view won't get reset to initialZoom on reaching maxZoom                                                                                   | false   |
+| bindToBorders              | boolean | If true, it makes sure the object stays within box borders                                                                                             | true    |
+| zoomStep                   | number  | How much zoom should be applied on double tap                                                                                                          | 0.5     |
+| pinchToZoomInSensitivity   | number  | the level of resistance (sensitivity) to zoom in (0 - 10) - higher is less sensitive                                                                   | 3       |
+| pinchToZoomOutSensitivity  | number  | the level of resistance (sensitivity) to zoom out (0 - 10) - higher is less sensitive                                                                  | 1       |
+| zoomCenteringLevelDistance | number  | the (zoom level - 0 - maxZoom) distance for pinch to zoom actions until they are shifted on new pinch to zoom center - higher means it centeres slower | 0.5     |
+| movementSensibility        | number  | how resistant should shifting the view around be? (0.5 - 5) - higher is less sensitive                                                                 | 1.9     |
+| initialOffsetX             | number  | The horizontal offset the image should start at                                                                                                        | 0       |
+| initialOffsetY             | number  | The vertical offset the image should start at                                                                                                          | 0       |
+| longPressDuration          | number  | Duration in ms until a press is considered a long press                                                                                                | 700     |
+| captureEvent               | boolean | Defines whether the pan responder of the parent element should be captured. (useful for react-native modals, set it to true)                           | false   |
 
 #### Callbacks
 
 These events can be used to work with data after specific events.
 
-| name | description | params | expected return |
-| ---- | ----------- | ------ | --------------- |
-| onDoubleTapBefore | Will be called, at the start of a double tap | event, gestureState, zoomableViewEventObject | void |
-| onDoubleTapAfter | Will be called at the end of a double tap | event, gestureState, zoomableViewEventObject | void |
-| onShiftingBefore | Will be called, when user taps and moves the view, but before our view movement work kicks in (so this is the place to interrupt movement, if you need to)  | event, gestureState, zoomableViewEventObject |  {boolean} if this returns true, ZoomableView will not process the shift, otherwise it will |
-| onShiftingAfter | Will be called, when user taps and moves the view, but after the values have changed already | event, gestureState, zoomableViewEventObject | void |
-| onShiftingEnd | Will be called, when user stops a tap and move gesture | event, gestureState, zoomableViewEventObject | void |
-| onZoomBefore | Will be called, while the user pinches the screen, but before our zoom work kicks in (so this is the place to interrupt zooming, if you need to) | event, gestureState, zoomableViewEventObject | {boolean} if this returns true, ZoomableView will not process the pinch, otherwise it will |
-| onZoomAfter | Will be called, while the user pinches the screen, but after the values have changed already | event, gestureState, zoomableViewEventObject | {boolean} if this returns true, ZoomableView will not process the pinch, otherwise it will |
-| onZoomEnd | Will be called after pinchzooming has ended | event, gestureState, zoomableViewEventObject | {boolean} if this returns true, ZoomableView will not process the pinch, otherwise it will |
-| onLongPress | Will be called after the user pressed on the image for a while | event, gestureState | void | 
-
+| name              | description                                                                                                                                                | params                                       | expected return                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| onDoubleTapBefore | Will be called, at the start of a double tap                                                                                                               | event, gestureState, zoomableViewEventObject | void                                                                                       |
+| onDoubleTapAfter  | Will be called at the end of a double tap                                                                                                                  | event, gestureState, zoomableViewEventObject | void                                                                                       |
+| onShiftingBefore  | Will be called, when user taps and moves the view, but before our view movement work kicks in (so this is the place to interrupt movement, if you need to) | event, gestureState, zoomableViewEventObject | {boolean} if this returns true, ZoomableView will not process the shift, otherwise it will |
+| onShiftingAfter   | Will be called, when user taps and moves the view, but after the values have changed already                                                               | event, gestureState, zoomableViewEventObject | void                                                                                       |
+| onShiftingEnd     | Will be called, when user stops a tap and move gesture                                                                                                     | event, gestureState, zoomableViewEventObject | void                                                                                       |
+| onZoomBefore      | Will be called, while the user pinches the screen, but before our zoom work kicks in (so this is the place to interrupt zooming, if you need to)           | event, gestureState, zoomableViewEventObject | {boolean} if this returns true, ZoomableView will not process the pinch, otherwise it will |
+| onZoomAfter       | Will be called, while the user pinches the screen, but after the values have changed already                                                               | event, gestureState, zoomableViewEventObject | {boolean} if this returns true, ZoomableView will not process the pinch, otherwise it will |
+| onZoomEnd         | Will be called after pinchzooming has ended                                                                                                                | event, gestureState, zoomableViewEventObject | {boolean} if this returns true, ZoomableView will not process the pinch, otherwise it will |
+| onLongPress       | Will be called after the user pressed on the image for a while                                                                                             | event, gestureState                          | void                                                                                       |
 
 #### Events
 
@@ -170,13 +171,12 @@ The following events allow you to control the ZoomableView zoom level & position
 
 You can find an implementation example in the example repo: https://github.com/DuDigital/react-native-zoomable-view-example
 
-| name | description | params | expected return |
-| ---- | ----------- | ------ | --------------- |
-| zoomTo | Changes the zoom level to a specific number | newZoomLevel: number, bindToBorders = true | Promise<bool> |
-| zoomBy | Changes the zoom level relative to the current level (use positive numbers to zoom in, negative numbers to zoom out) | zoomLevelChange: number, bindToBorders = true | Promise<bool> |
-| moveTo | Shifts the zoomed part to a specific point (in px relative to x: 0, y: 0) | newOffsetX: number, newOffsetY: number, bindToBorders = true | Promise<void> |
-| moveBy | Shifts the zoomed part by a specific pixel number | newOffsetX: number, newOffsetY: number, bindToBorders = true | Promise<void> |
-
+| name   | description                                                                                                          | params                                                       | expected return |
+| ------ | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------- |
+| zoomTo | Changes the zoom level to a specific number                                                                          | newZoomLevel: number, bindToBorders = true                   | Promise<bool>   |
+| zoomBy | Changes the zoom level relative to the current level (use positive numbers to zoom in, negative numbers to zoom out) | zoomLevelChange: number, bindToBorders = true                | Promise<bool>   |
+| moveTo | Shifts the zoomed part to a specific point (in px relative to x: 0, y: 0)                                            | newOffsetX: number, newOffsetY: number, bindToBorders = true | Promise<void>   |
+| moveBy | Shifts the zoomed part by a specific pixel number                                                                    | newOffsetX: number, newOffsetY: number, bindToBorders = true | Promise<void>   |
 
 **Example:**
 
@@ -222,24 +222,24 @@ export default function App() {
 
 ```
 
-
 #### Pan Responder Hooks
 
 Sometimes you need to change deeper level behavior, so we prepared these panresponder hooks for you.
 
-| name | description | params | expected return |
-| ---- | ----------- | ------ | --------------- |
-| onStartShouldSetPanResponder | description | event, gestureState, zoomableViewEventObject, baseComponentResult | {boolean} whether panresponder should be set or not |
-| onMoveShouldSetPanResponder | description | event, gestureState, zoomableViewEventObject, baseComponentResult | {boolean} whether panresponder should be set or not |
-| onPanResponderGrant | description | event, gestureState, zoomableViewEventObject | void |
-| onPanResponderEnd | Will be called when gesture ends (more accurately, on pan responder "release") | event, gestureState, zoomableViewEventObject | void |
-| onPanResponderTerminate | Will be called when the gesture is force-interrupted by another handler | event, gestureState, zoomableViewEventObject | void |
-| onPanResponderTerminationRequest | Callback asking whether the gesture should be interrupted by another handler (**iOS only** due to https://github.com/facebook/react-native/issues/27778, https://github.com/facebook/react-native/issues/5696, ...) | event, gestureState, zoomableViewEventObject | void |
-| onPanResponderMove | Will be called when user moves while touching | event, gestureState, zoomableViewEventObject | void |
+| name                             | description                                                                                                                                                                                                         | params                                                            | expected return                                     |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+| onStartShouldSetPanResponder     | description                                                                                                                                                                                                         | event, gestureState, zoomableViewEventObject, baseComponentResult | {boolean} whether panresponder should be set or not |
+| onMoveShouldSetPanResponder      | description                                                                                                                                                                                                         | event, gestureState, zoomableViewEventObject, baseComponentResult | {boolean} whether panresponder should be set or not |
+| onPanResponderGrant              | description                                                                                                                                                                                                         | event, gestureState, zoomableViewEventObject                      | void                                                |
+| onPanResponderEnd                | Will be called when gesture ends (more accurately, on pan responder "release")                                                                                                                                      | event, gestureState, zoomableViewEventObject                      | void                                                |
+| onPanResponderTerminate          | Will be called when the gesture is force-interrupted by another handler                                                                                                                                             | event, gestureState, zoomableViewEventObject                      | void                                                |
+| onPanResponderTerminationRequest | Callback asking whether the gesture should be interrupted by another handler (**iOS only** due to https://github.com/facebook/react-native/issues/27778, https://github.com/facebook/react-native/issues/5696, ...) | event, gestureState, zoomableViewEventObject                      | void                                                |
+| onPanResponderMove               | Will be called when user moves while touching                                                                                                                                                                       | event, gestureState, zoomableViewEventObject                      | void                                                |
 
 ### zoomableViewEventObject
 
 The zoomableViewEventObject object is attached to every event and represents the current state of our zoomable view.
+
 ```
    {
       zoomLevel: number,         // current level of zooming (usually a value between minZoom and maxZoom)
@@ -256,7 +256,7 @@ The zoomableViewEventObject object is attached to every event and represents the
       lastMovePinch: boolean,    // boolean, that states if this movement was a pinch movement
       originalHeight: number,    // original height of the outer view
       originalWidth: number,     // original width of the outer view
-      captureEvent: boolean,     // should the panresponder be taken away from parent component (used for react-native modals) 
+      captureEvent: boolean,     // should the panresponder be taken away from parent component (used for react-native modals)
    }
 ```
 
@@ -267,12 +267,11 @@ The zoomableViewEventObject object is attached to every event and represents the
 To make this work with react-native modals, you have to set the `captureEvent` prop to `true`.
 Otherwise the modal will stop the pinch2zoom event and it will not work.
 
-
 ## TODO
 
-* Improve documentation
-* Add examples for more complex scenarios (react-native-zoomable-view in a swiper)
-* TESTS
+- Improve documentation
+- Add examples for more complex scenarios (react-native-zoomable-view in a swiper)
+- TESTS
 
 ## Contributing
 

--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -47,6 +47,7 @@ class ReactNativeZoomableView extends Component<ReactNativeZoomableViewProps, Re
     onLongPress: null,
     longPressDuration: 700,
     captureEvent: false,
+    stayAtMaxZoom: false,
   };
 
   constructor(props) {
@@ -634,11 +635,11 @@ class ReactNativeZoomableView extends Component<ReactNativeZoomableViewProps, Re
    * @returns {*}
    */
   _getNextZoomStep() {
-    const { zoomStep, maxZoom, initialZoom } = this.props;
+    const { zoomStep, maxZoom, initialZoom, stayAtMaxZoom } = this.props;
     const { zoomLevel } = this.state;
 
     if (zoomLevel === maxZoom) {
-      return initialZoom;
+      return stayAtMaxZoom ? maxZoom : initialZoom;
     }
 
     let nextZoomStep = zoomLevel + zoomLevel * zoomStep;

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -44,6 +44,7 @@ declare module '@dudigital/react-native-zoomable-view' {
     longPressDuration?: number;
     captureEvent?: boolean;
     style?: any;
+    stayAtMaxZoom?: boolean;
 
     // callbacks
     onDoubleTapBefore?: (


### PR DESCRIPTION
This PR includes a new optional Boolean parameter `stayAtMaxZoom`, that will conditionally return the next zoom step when user reached maximum zoom value.

**Scenario1:**
- user did not set this value in local.
- so framework will pick default value `false`
- user reached maximum zoom value and made double clicks.
- view is reset to initialZoom value

**Scenario 2:**
- user set `stayAtMaxZoom = true` in his local.
- user reached maximum zoom value and made double clicks.
- view won't get is reset to initialZoom instead stays at maximumZoom value.

I'm not sure how much this feature is useful to others, I need this requirement in my application. so I raised one feature request ( https://github.com/DuDigital/react-native-zoomable-view/issues/80) and this PR simultaneously.

