### PR TITLE
Fix double scale issue

### DIFF
--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -819,7 +819,6 @@ class ReactNativeZoomableView extends Component<ReactNativeZoomableViewProps, Re
             {
               transform: [
                 { scale: this.state.zoomLevel },
-                { scale: this.state.zoomLevel },
                 { translateX: this.state.offsetX },
                 { translateY: this.state.offsetY },
               ],


### PR DESCRIPTION
The `scale` transformation was mistakenly applying twice.