### PR TITLE
Fix typings path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Here is a full drop in example you can use in Expo, after installing the package
 ```JSX
 import React from 'react';
 import { View, Image } from 'react-native';
-import ReactNativeZoomableView from '@dudigital/react-native-zoomable-view/src/ReactNativeZoomableView';
+import { ReactNativeZoomableView } from '@dudigital/react-native-zoomable-view';
 
 export default class App extends React.Component {
   /**

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/DuDigital/react-native-zoomable-view/issues"
   },
   "homepage": "https://github.com/DuDigital/react-native-zoomable-view#readme",
-  "types": "typings/index.d.ts",
+  "types": "src/typings/index.d.ts",
   "dependencies": {
     "prop-types": "^15.7.2",
     "react-native": ">=0.54.0"


### PR DESCRIPTION
Due to wrong `types` path in the `package.json`, we could not properly import the component.
After merging this PR, we'll be able to import it like that:

```
import { ReactNativeZoomableView } from '@dudigital/react-native-zoomable-view';
```

instead of
```
import ReactNativeZoomableView from '@dudigital/react-native-zoomable-view/src/ReactNativeZoomableView';
```