### PR TITLE
Fix zoomTo greater than or equal to max/min-size

### DIFF
--- a/src/ReactNativeZoomableView.tsx
+++ b/src/ReactNativeZoomableView.tsx
@@ -730,7 +730,7 @@ class ReactNativeZoomableView extends Component<ReactNativeZoomableViewProps, Re
   zoomTo(newZoomLevel: number, bindToBorders = true): Promise<boolean> {
     return new Promise((resolve) => {
       // if we would go out of our min/max limits -> abort
-      if (newZoomLevel >= this.props.maxZoom || newZoomLevel <= this.props.minZoom) {
+      if (newZoomLevel > this.props.maxZoom || newZoomLevel < this.props.minZoom) {
         resolve(false);
         return;
       }


### PR DESCRIPTION
The zoomTo event now also supports the minZoom value and the maxZoom value.

Before you could not zoom to 1 with zoomTo if the minZoom was 1.